### PR TITLE
ci: config code linter in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+-   repo: https://github.com/golangci/golangci-lint # golangci-lint hook repo
+    rev: v1.54.0 # golangci-lint hook repo revision
+    hooks:
+    - id: golangci-lint
+      name: golangci-lint
+      description: Fast linters runner for Go.
+      entry: golangci-lint run --fix
+      types: [go]
+      language: golang
+      pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -42,10 +42,20 @@ gop run .
 
 1. **Fork the repository to your local repo**
 
-2. **Modify your own code**
+2. **Config code linter**
+  
+    ```bash
+    // install pre-commit
+    pip install pre-commit
 
-3. **Commit your code**
+    // config code linter in pre-commit hook
+    pre-commit install
+    ```
 
-4. **Create a pull request**
+3. **Modify your own code**
+
+4. **Commit your code**
+
+5. **Create a pull request**
 
 > **Note:** Please check the PR brach is `mvp-20240119` or not.


### PR DESCRIPTION
# Feature
Configure code linter on the local machine to lint the code before committing it.

# Usage
1. install pre-commit
```bash
pip install pre-commit
```
2. config code linter in pre-commit hook
```bash
pre-commit install
```

# Test
![image](https://github.com/goplus/community/assets/133086269/65b3d56d-a950-4b84-88af-4e67a3c055b2)
