### PR TITLE
fix: enhance article list ui

### DIFF
--- a/cmd/gopcomm/yap/home_yap.html
+++ b/cmd/gopcomm/yap/home_yap.html
@@ -102,10 +102,11 @@
                     --n-tab-border-radius: 7px; --n-tab-font-weight-active: 600; --n-tab-gap: 10px;
                     --n-color-segment: #dfebf7; --n-tab-padding: 5% 0; --n-tab-font-size: 17px;
                     --n-tab-text-color-active: #3182ce; --n-tab-text-color-hover: #6ea8de;">
+                    <!-- Article -->
                     <n-tab-pane name="article">
                         <template #tab>
                             <img src="./static/img/logo-blog.svg" width="25" height="25" class="mr-3">
-                            BLOG
+                            ARTICLE
                         </template>
                         <!-- Content -->
                         <div class="container px-5 py-2 mx-auto bg-white rounded-lg"
@@ -138,11 +139,11 @@
                             <!-- Article List -->
                             <n-list hoverable v-else>
                                 <!-- Article List Item -->
-                                <n-list-item v-for="(item, i) in articleList.article">
+                                <n-list-item v-for="(item, i) in articleList.article" class="py-3">
                                     <!-- left part -->
-                                    <div style="width: 80%;">
+                                    <div style="width: 75%;">
                                         <!-- Title -->
-                                        <div class="text-xl font-semibold text-gray-900 title-font mb-1">
+                                        <div class="text-xl text-gray-900 mb-2" style="font-weight: 500;">
                                             <a :href="'/article/' + item.ID">
                                                 <p>${ item.Title }</p>
                                             </a>
@@ -153,16 +154,16 @@
                                             <!-- A Tag -->
                                             <div class="flex flex-row items-center mr-2" v-for="(tag, i) in item.Tags.split(';')">
                                                 <i class="ph-duotone ph-hash" style="color: #3182ce; font-size: 17px;"></i>
-                                                <div>
+                                                <p class="text-sm ml-1 mr-2">
                                                     <a class="text-sm" :href="'/search?value=' + tag + '&label=article'">
                                                         ${ tag }
                                                     </a>
-                                                </div>
+                                                </p>
                                             </div>
                                         </div>
 
                                         <!-- Description -->
-                                        <p class="leading-7 mt-1 mb-2" style="color: #6b7280; line-height: normal;">
+                                        <p class="ellipsis">
                                             ${ item.Abstract }
                                         </p>
 
@@ -170,15 +171,16 @@
                                         <div class="flex items-center absolute bottom-4">
                                             <a class="flex items-center" :href="'/user/' + item.User.Id">
                                                 <!-- Avatar -->
-                                                <n-avatar class="mr-2" round :size="25" :src="item.User.Avatar"></n-avatar>
+                                                <n-avatar class="mr-2" round :size="28" :src="item.User.Avatar"></n-avatar>
 
                                                 <!-- Nick Name -->
-                                                <p class="text-sm font-medium mr-1 text-black">${ item.User.Name }</p>
+                                                <p class="mr-2" style="font-size: 15px;">${ item.User.Name }</p>
                                             </a>
 
                                             <!-- Update Time -->
-                                            <span class="text-xs" style="color: #A0AEC0;">
-                                                · ${ item.Ctime.slice(0,10) }
+                                            <span class="text-sm" style="color: #A0AEC0;">
+                                                · 
+                                                <span class="ml-1">${ item.Ctime.slice(0,10) }</span>
                                             </span>
                                         </div>
                                     </div>
@@ -186,22 +188,19 @@
                                     <!-- right part -->
                                     <div style="width: 20%;">
                                         <!-- Image -->
-                                        <!-- TODO: 封面图 -->
-                                        <img class="w-full object-cover rounded-lg" style="height: 15vh;" :src="item.Cover || './static/img/default-cover.jpg'" alt="">
+                                        <img class="w-full object-cover rounded-lg" style="height: 17vh;" :src="item.Cover || './static/img/default-cover.jpg'" alt="">
 
                                         <!-- Data -->
                                         <div class="flex justify-center items-center mt-2" style="height: 2vh;">
                                             <!-- Views -->
                                             <div class="flex justify-center items-center" style="width: 40%;">
-                                                <i class="ph-duotone ph-eye" style="color: #6091d2;"></i>
-                                                <!-- TODO: 浏览量 -->
+                                                <i class="ph-duotone ph-eye" style="color: #7ba7d3; font-size: 18px;"></i>
                                                 <span class="ml-1 text-sm"> ${ item.ViewCount }</span>
                                             </div>
 
                                             <!-- Likes -->
                                             <div class="flex justify-center items-center" style="width: 40%;">
-                                                <i class="ph-duotone ph-thumbs-up" style="color: #6091d2;"></i>
-                                                <!-- TODO: 点赞数 -->
+                                                <i class="ph-duotone ph-heart" style="color: #df8282; font-size: 18px;"></i>
                                                 <span class="ml-1 text-sm"> ${ item.LikeCount }</span>
                                             </div>
                                         </div>
@@ -220,6 +219,8 @@
                             </div>
                         </div>
                     </n-tab-pane>
+
+                    <!-- Video -->
                     <n-tab-pane name="video">
                         <template #tab>
                             <img src="./static/img/logo-video.svg" width="25" height="25" class="mr-3">
@@ -340,6 +341,8 @@
                             </div>
                         </div>
                     </n-tab-pane>
+
+                    <!-- STEM -->
                     <n-tab-pane name="stem">
                         <template #tab>
                             <img src="./static/img/logo-stem.svg" width="25" height="25" class="mr-3">
@@ -462,8 +465,6 @@
                     </n-tab-pane>
                 </n-tabs>
             </div>
-
-            
         </div>
 
         <script>
@@ -657,9 +658,28 @@
     .n-list .n-list-item .n-list-item__main {
         display: flex;
         flex-direction: row;
+        justify-content: space-between;
     }
+
+    .n-list.n-list--bordered .n-list-item, .n-list.n-list--hoverable .n-list-item {
+        padding: 18px 23px;
+    }
+
     .n-tabs .n-tabs-nav{
         width: 70%;
         margin: auto;
+    }
+
+    .ellipsis {
+        margin: 7px 0 20px 0;
+        color: #80878e; 
+        font-size: 15px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 2; /* 控制文本的行数 */
+        -webkit-box-orient: vertical;
+        /* max-height: 50px; 根据行高和行数调整 */
+        /* line-height: 18px; 示例行高 */
     }
 </style>


### PR DESCRIPTION
fix bug: https://github.com/goplus/community/issues/214

- Modify the UI style with reference to Medium and InfoQ according to leader's advice.
- Add ellipsis to the article description.
![image](https://github.com/goplus/community/assets/96371110/3332abc3-39d7-42ca-be57-39d35ddc0454)

Medium:
![image](https://github.com/goplus/community/assets/96371110/b539173b-87da-4fd9-adac-d8374f651957)

InfoQ:
![image](https://github.com/goplus/community/assets/96371110/24652508-0c2c-44fb-a727-e86257535fbf)

There seems to be a display problem with article title's font weight: Under the Win system, there is no font weight display between `normal` and `bold`, which may not meet the leader's expectations.
refer: https://blog.zengrong.net/post/font-weight-500/
Therefore, either use `bold` or `normal`. The effect is as shown in the screenshot of Medium and InfoQ above. @CarlJi Please decide.