### PR TITLE
fix: use wechat-oa login, username unfriendly

### DIFF
--- a/internal/core/user.go
+++ b/internal/core/user.go
@@ -1,7 +1,10 @@
 package core
 
 import (
+	"math/rand"
 	"os"
+	"strconv"
+	"time"
 
 	"golang.org/x/oauth2"
 
@@ -93,6 +96,18 @@ func (p *Community) GetUser(token string) (user *User, err error) {
 		return &User{}, ErrNotExist
 	}
 	user, err = p.GetUserById(claim.Id)
+	userId := user.Id
+	if user.Name == "wx_user_"+userId {
+		rand.Seed(time.Now().UnixNano())
+		name := "GOP" + strconv.Itoa(rand.Intn(100000000))
+		claim.User.DisplayName = name
+		_, err := casdoorsdk.UpdateUserById(claim.User.GetId(), &claim.User)
+		if err != nil {
+			p.xLog.Error(err.Error())
+		} else {
+			user.Name = name
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
# 背景
在使用公众号登录后用户显示昵称为wx_user_ + xxxxxxxx，对于用户体验极不友好，因此需要修改昵称

# 方案

- 用户首次使用公众号登录后，弹框显示 "请修改用户昵称等信息" -> 友好提示用户修改昵称
- 用户首次使用公众号登录后，强制修改用户昵称为自定义名称
- casdoor方面提pr，可自定义用户昵称算法

**方案流程**
1.需要在表中添加字段用于记录弹框标记，避免后续再次弹框
2.用户无感知，较友好
3.casdoor方面需要在公众号页面预留添加用户昵称算法拓展点

**采取方案**
2

该方案实现简单，动用代码少，且能尽快实现

# 测试

- 使用公众号登录后查看用户信息昵称是否发生改变
