### PR TITLE
fix: article translate original

### DIFF
--- a/cmd/gopcomm/yap/article_yap.html
+++ b/cmd/gopcomm/yap/article_yap.html
@@ -257,7 +257,7 @@
         const originArticle = {{.Article}};
         const likeState = {{.LikeState}}
         const user = {{.User}}
-        const article = ref(originArticle);
+        const article = ref(Object.assign({}, originArticle));
 
         let transArticle = {}
         const transOptions = [


### PR DESCRIPTION
Fixed the issue where clicking on the original text after translation fails.